### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/alxhill/preempt-rt/compare/v0.1.1...v0.2.0) - 2025-07-23
+
+### Added
+
+- add stubs for  macos compile through non-linux-stubs feature ([#4](https://github.com/alxhill/preempt-rt/pull/4))
+
 ## [0.1.1](https://github.com/alxhill/preempt-rt/compare/v0.1.0...v0.1.1) - 2025-07-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "preempt-rt"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preempt-rt"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 description = "A lightweight Rust library for using the kernel's PREEMPT_RT scheduling functionality"


### PR DESCRIPTION



## 🤖 New release

* `preempt-rt`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `preempt-rt` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant PreemptRtError:NonLinuxPlatform in /tmp/.tmpavjPMd/preempt-rt/src/sched.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/alxhill/preempt-rt/compare/v0.1.1...v0.2.0) - 2025-07-23

### Added

- add stubs for  macos compile through non-linux-stubs feature ([#4](https://github.com/alxhill/preempt-rt/pull/4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).