### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/alxhill/preempt-rt/compare/v0.2.1...v0.3.0) - 2025-07-23
+
+### Other
+
+- additional doc cleanup ([#8](https://github.com/alxhill/preempt-rt/pull/8))
+
 ## [0.2.1](https://github.com/alxhill/preempt-rt/compare/v0.2.0...v0.2.1) - 2025-07-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "preempt-rt"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preempt-rt"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 description = "A lightweight Rust library for using the kernel's PREEMPT_RT scheduling functionality"


### PR DESCRIPTION



## 🤖 New release

* `preempt-rt`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `preempt-rt` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Scheduler::with_priority, previously in file /tmp/.tmpiPfvVv/preempt-rt/src/sched.rs:125

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait preempt_rt::sched::IntoSchedParam, previously in file /tmp/.tmpiPfvVv/preempt-rt/src/sched.rs:185
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/alxhill/preempt-rt/compare/v0.2.1...v0.3.0) - 2025-07-23

### Other

- additional doc cleanup ([#8](https://github.com/alxhill/preempt-rt/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).