### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/alxhill/preempt-rt/compare/v0.3.0...v0.3.1) - 2025-07-25
+
+### Other
+
+- remove unused ci task ([#10](https://github.com/alxhill/preempt-rt/pull/10))
+
 ## [0.3.0](https://github.com/alxhill/preempt-rt/compare/v0.2.1...v0.3.0) - 2025-07-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "preempt-rt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preempt-rt"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 description = "A lightweight Rust library for using the kernel's PREEMPT_RT scheduling functionality"


### PR DESCRIPTION



## 🤖 New release

* `preempt-rt`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/alxhill/preempt-rt/compare/v0.3.0...v0.3.1) - 2025-07-25

### Other

- remove unused ci task ([#10](https://github.com/alxhill/preempt-rt/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).