### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/alxhill/preempt-rt/compare/v0.4.1...v0.4.2) - 2025-07-31
+
+### Other
+
+- add cargo metadata ([#16](https://github.com/alxhill/preempt-rt/pull/16))
+
 ## [0.4.1](https://github.com/alxhill/preempt-rt/compare/v0.4.0...v0.4.1) - 2025-07-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "preempt-rt"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preempt-rt"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT"
 description = "A lightweight Rust library for using the kernel's PREEMPT_RT scheduling functionality"


### PR DESCRIPTION



## 🤖 New release

* `preempt-rt`: 0.4.1 -> 0.4.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/alxhill/preempt-rt/compare/v0.4.1...v0.4.2) - 2025-07-31

### Other

- add cargo metadata ([#16](https://github.com/alxhill/preempt-rt/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).