### PR TITLE
ci: use trusted publishing for release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,8 +10,10 @@ jobs:
     name: Release-plz release
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'alxhill' }}
+    environment: crates
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +28,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
Switch the release-plz release job to crates.io trusted publishing (OIDC).

## Changes
- Add `environment: crates` (already configured in crates.io) to the release job.
- Add `id-token: write` permission to enable OIDC token minting.
- Remove the `CARGO_REGISTRY_TOKEN` env var — release-plz automatically uses trusted publishing when no registry token is present and `id-token: write` is granted.

The `release-plz-pr` job is left unchanged since it only opens PRs and doesn't publish.

After confirming a release works, the `CARGO_REGISTRY_TOKEN` secret can be deleted from the repo.