### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/alxhill/preempt-rt/compare/v0.4.3...v0.4.4) - 2026-05-29
+
+### Other
+
+- fix outdated set_scheduler example in README ([#22](https://github.com/alxhill/preempt-rt/pull/22))
+- use trusted publishing for release-plz ([#20](https://github.com/alxhill/preempt-rt/pull/20))
+
 ## [0.4.3](https://github.com/alxhill/preempt-rt/compare/v0.4.2...v0.4.3) - 2025-10-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "preempt-rt"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preempt-rt"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT"
 description = "A lightweight Rust library for using the kernel's PREEMPT_RT scheduling functionality"


### PR DESCRIPTION



## 🤖 New release

* `preempt-rt`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/alxhill/preempt-rt/compare/v0.4.3...v0.4.4) - 2026-05-29

### Other

- fix outdated set_scheduler example in README ([#22](https://github.com/alxhill/preempt-rt/pull/22))
- use trusted publishing for release-plz ([#20](https://github.com/alxhill/preempt-rt/pull/20))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).